### PR TITLE
Streamline KLCM for ZMK-only + pedal docs & diode technique

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -607,5 +607,41 @@ The cheyo branch initially omitted the pedal keys from the keymap. This caused:
 
 The main branch and dcpedit's reference implementation correctly include all 3 pedals. This was corrected to ensure keymap matrix completeness.
 
-**Hardware Note**:
-The pedal connections on the Pillz Mod Pro PCB can be repurposed for other matrix repairs. In this case, Pedal 1's matrix position is used to reroute a broken `X` key pad on an older Kinesis keyboard, allowing that key to function again without PCB repair.
+**Hardware Note - Rerouting Broken Keys via Pedal Matrix**:
+The pedal connections on the Pillz Mod Pro PCB can be repurposed for matrix repairs. In this case, Pedal 1's matrix position is used to reroute a broken `X` key pad on an older Kinesis keyboard.
+
+**Anti-Ghosting Diode Technique**:
+When rerouting a key through an alternate matrix position (like using a pedal input for a regular key), you must add diodes to prevent current from flowing backwards through the matrix, which would cause key ghosting (phantom keypresses).
+
+The technique involves adding a pair of diodes in series with the rerouted key connection:
+- One diode on each leg of the switch connection
+- Diodes oriented to only allow current flow in the correct scanning direction
+- This isolates the rerouted key from interfering with other keys in the same row/column
+
+**Diode Orientation**:
+The dark band/stripe on a diode marks the **cathode** (negative) side - think of it as a tiny wall or dam.
+
+```
+     Current flows this way →
+          ┌─────────┐
+    ──────┤    →    ┣━━━━━━──
+          └─────────┘
+    Anode (+)       Cathode (-)
+                    ━━━ ← Dark stripe
+```
+
+**Current flow: Anode → Cathode (towards the stripe)**
+
+**The stripe is a one-way gate:**
+- Current CAN flow **towards** the stripe (anode → cathode) ✓
+- Current CANNOT flow **away from** the stripe (cathode → anode) ✗
+
+**Simple mental model:**
+Think of the dark stripe as a little flow blocker. Current flows INTO the stripe side and stops there — it cannot flow out from that side going backwards.
+
+For keyboard matrix isolation:
+- Orient diodes so the stripe points TOWARDS the row/column line
+- Current flows FROM the switch, TO the stripe, INTO the matrix
+- Reverse current (from matrix back to switch) is blocked by the stripe
+
+Without these diodes, pressing the rerouted key could trigger false readings on other keys that share the same row or column in the original matrix.

--- a/configs/zmk_adv_mod/pillzmod_pro.keymap
+++ b/configs/zmk_adv_mod/pillzmod_pro.keymap
@@ -193,7 +193,7 @@
                                                       &mo LAYER_KEYPAD  &kp LEFT_WIN                                       &kp ESC  &mo LAYER_KEYPAD
                                                                         &kp LEFT_CONTROL                                   &kp LEFT_CONTROL
                                         &kp SPACE   &kp LEFT_SHIFT      &kp LEFT_ALT                                       &mo LAYER_CMD  &kp RIGHT_SHIFT &kp SPACE
-    &kp X  &kp ESC  &kp ESC
+    &kp ESC  &kp X  &kp Z
             >;
         };
         


### PR DESCRIPTION
## Summary
- Archive non-ZMK configs (kinesis2, qmk_ergodox) to `configs/archived/`
- Remove unused QMK/Kinesis2 parser stubs and model types
- Focus on 3 active ZMK keyboards: adv360, glove80, adv_mod

## Pillz Mod Pro Pedal Documentation
- Document pedal matrix positions (RC(0,6), RC(1,6), RC(2,6))
- Explain why pedals are unique to Pillz Mod Pro (not on Adv360/Glove80)
- Document historical bug where cheyo branch omitted pedals

## Anti-Ghosting Diode Technique
- Document how to reroute broken keys via pedal matrix positions
- Explain diode orientation (current flows anode → cathode, towards the stripe)
- Describe anti-ghosting isolation technique for matrix repairs

## Files Changed
- **configs/**: Moved kinesis2 and qmk_ergodox to archived/
- **internal/**: Simplified parsers and models for ZMK-only
- **AGENTS.md**: Added Section 10 for pedals + diode technique
- **README.md**: Simplified for ZMK workflow